### PR TITLE
consumer/handler: Migrate Handler and HandlerFunc from kafka-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,28 @@
 
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -17,12 +33,24 @@
   pruneopts = "UT"
   revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
 
+[[projects]]
+  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = "UT"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/pkg/errors",
     "github.com/satori/go.uuid",
+    "github.com/stretchr/testify/require",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/consumer/handler/func.go
+++ b/consumer/handler/func.go
@@ -1,0 +1,20 @@
+package handler
+
+import (
+	"github.com/heetch/felice/message"
+)
+
+// A HandleMessageFn is a function type that can be passed to
+// HandlerFunc.  Its signature mimics the interface of the
+// HandleMessage function in the Handler interface.
+type HandleMessageFn func(*message.Message) error
+
+func (h *HandleMessageFn) HandleMessage(msg *message.Message) error {
+	return (*h)(msg)
+}
+
+// HandlerFunc wraps a HandleMessagFn in such a way that it complies
+// with the Handler interface.
+func HandlerFunc(fn HandleMessageFn) Handler {
+	return &fn
+}

--- a/consumer/handler/func_test.go
+++ b/consumer/handler/func_test.go
@@ -1,0 +1,24 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/heetch/felice/consumer/handler"
+	"github.com/heetch/felice/message"
+	"github.com/stretchr/testify/require"
+)
+
+// HandleMessageFn can be used as a Handler
+func TestHandleMessageFn(t *testing.T) {
+	calls := make([]bool, 0)
+
+	var h handler.Handler
+	h = handler.HandlerFunc(func(msg *message.Message) error {
+		calls = append(calls, true)
+		return nil
+	})
+	m := &message.Message{}
+	err := h.HandleMessage(m)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+}

--- a/consumer/handler/interface.go
+++ b/consumer/handler/interface.go
@@ -1,0 +1,8 @@
+package handler
+
+import "github.com/heetch/felice/message"
+
+// A Handler handles a Message.
+type Handler interface {
+	HandleMessage(*message.Message) error
+}


### PR DESCRIPTION
This PR fixes #8 

- Migrate `Handler` interface from kafka-go
- Migrate `HandlerFunc` from kafka-go
- Factor away `funcHandler` struct - we can just hang the `HandleMessage` function off of a defined type for the method signature instead (I call this `HandleMessageFn`)
- 100% test coverage :100: 