### PR TITLE
Import Producer from kafka-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,66 @@
 
 
 [[projects]]
+  digest = "1:b6957a1836b6d7e51e5a71391f5c08fa5d866f57e4ac425fa5f183d518a5657b"
+  name = "github.com/Shopify/sarama"
+  packages = [
+    ".",
+    "mocks",
+  ]
+  pruneopts = "UT"
+  revision = "ec843464b50d4c8b56403ec9d589cf41ea30e722"
+  version = "v1.19.0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:1f0c7ab489b407a7f8f9ad16c25a504d28ab461517a971d341388a56156c1bd7"
+  name = "github.com/eapache/go-resiliency"
+  packages = ["breaker"]
+  pruneopts = "UT"
+  revision = "ea41b0fad31007accc7f806884dcdf3da98b79ce"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:79f16588b5576b1b3cd90e48d2374cc9a1a8776862d28d8fd0f23b0e15534967"
+  name = "github.com/eapache/go-xerial-snappy"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "776d5712da21bc4762676d614db1d8a64f4238b0"
+
+[[projects]]
+  digest = "1:444b82bfe35c83bbcaf84e310fb81a1f9ece03edfed586483c869e2c046aef69"
+  name = "github.com/eapache/queue"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "44cc805cf13205b55f69e14bcb69867d1ae92f98"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+
+[[projects]]
+  digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"
+  name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = "UT"
+  revision = "635575b42742856941dbc767b44905bb9ba083f6"
+  version = "v2.0.7"
 
 [[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
@@ -24,6 +78,14 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c4556a44e350b50a490544d9b06e9fba9c286c21d6c0e47f54f3a9214597298c"
+  name = "github.com/rcrowley/go-metrics"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
   branch = "master"
@@ -48,6 +110,8 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/Shopify/sarama",
+    "github.com/Shopify/sarama/mocks",
     "github.com/pkg/errors",
     "github.com/satori/go.uuid",
     "github.com/stretchr/testify/require",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,6 +32,10 @@
   name = "github.com/pkg/errors"
   version = "0.8.0"
 
+[[constraint]]
+  name = "github.com/Shopify/sarama"
+  version = "1.16.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -26,15 +26,13 @@ func TestNewWithEmptyValue(t *testing.T) {
 // message.New should return an error if no topic name is provided.
 func TestNewWithEmptyTopic(t *testing.T) {
 	_, err := message.New("", "Foo")
-	require.Error(t, err)
-	require.Equal(t, "messages require a non-empty topic", err.Error())
+	require.EqualError(t, err, "messages require a non-empty topic")
 }
 
 // message.New should return an error if the value provided cannot be marshaled
 func TestNewWithValueWhichCannotBeMarshaled(t *testing.T) {
 	_, err := message.New("test", make(chan bool))
-	require.Error(t, err)
-	require.Equal(t, "failed to encode message body: json: unsupported type: chan bool", err.Error())
+	require.EqualError(t, err, "failed to encode message body: json: unsupported type: chan bool")
 }
 
 // message.New returns a valid Message when provided valid parameters.

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -40,13 +40,15 @@ func newSaramaConfiguration(clientID string, maxRetry int) *sarama.Config {
 }
 
 // Send creates and sends a message to Kafka synchronously.
-func (p *Producer) Send(topic string, value interface{}, opts ...message.Option) error {
+// It returns the message.Message sent to the brokers.
+func (p *Producer) Send(topic string, value interface{}, opts ...message.Option) (*message.Message, error) {
 	msg, err := message.New(topic, value, opts...)
 	if err != nil {
-		return errors.Wrap(err, "producer: failed to create a message")
+		return nil, errors.Wrap(err, "producer: failed to create a message")
 	}
 
-	return p.SendMessage(msg)
+	err = p.SendMessage(msg)
+	return msg, err
 }
 
 // SendMessage sends the given message to Kafka synchronously.

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -1,0 +1,67 @@
+package producer
+
+import (
+	"github.com/Shopify/sarama"
+	"github.com/heetch/felice/message"
+	"github.com/pkg/errors"
+)
+
+// Producer sends messages to Kafka.
+// It embeds the sarama.SyncProducer type and shadows the Send method to
+// use our message.Message type.
+type Producer struct {
+	sarama.SyncProducer
+}
+
+// New creates a configured Producer.
+// This Producer is synchronous, it means that it will wait for all the replicas to
+// acknowledge the message.
+func New(clientID string, maxRetry int, addrs ...string) (*Producer, error) {
+	config := newSaramaConfiguration(clientID, maxRetry)
+	p, err := sarama.NewSyncProducer(addrs, config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a producer")
+	}
+
+	return &Producer{SyncProducer: p}, nil
+}
+
+func newSaramaConfiguration(clientID string, maxRetry int) *sarama.Config {
+	config := sarama.NewConfig()
+	config.Version = sarama.V1_0_0_0
+	config.ClientID = clientID
+	config.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message
+	config.Producer.Retry.Max = maxRetry             // Retry up to maxRetry times to produce the message
+	// required for the SyncProducer, see https://godoc.org/github.com/Shopify/sarama#SyncProducer
+	config.Producer.Return.Successes = true
+	config.Producer.Return.Errors = true
+
+	return config
+}
+
+// Send creates and sends a message to Kafka synchronously.
+func (p *Producer) Send(topic string, value interface{}, opts ...message.Option) error {
+	msg, err := message.New(topic, value, opts...)
+	if err != nil {
+		return errors.Wrap(err, "producer: failed to create a message")
+	}
+
+	return p.SendMessage(msg)
+}
+
+// SendMessage sends the given message to Kafka synchronously.
+func (p *Producer) SendMessage(msg *message.Message) error {
+	pmsg := &sarama.ProducerMessage{
+		Topic: msg.Topic,
+		Value: sarama.ByteEncoder(msg.Body),
+	}
+
+	if msg.Key != "" {
+		pmsg.Key = sarama.StringEncoder(msg.Key)
+	}
+
+	var err error
+	msg.Partition, msg.Offset, err = p.SyncProducer.SendMessage(pmsg)
+
+	return errors.Wrap(err, "failed to send message")
+}

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -14,7 +14,7 @@ type Producer struct {
 }
 
 // New creates a configured Producer.
-// This Producer is synchronous, it means that it will wait for all the replicas to
+// This Producer is synchronous, this means that it will wait for all the replicas to
 // acknowledge the message.
 func New(clientID string, maxRetry int, addrs ...string) (*Producer, error) {
 	config := newSaramaConfiguration(clientID, maxRetry)

--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -1,0 +1,46 @@
+package producer_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Shopify/sarama/mocks"
+	"github.com/heetch/felice/message"
+	"github.com/heetch/felice/producer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendMessage(t *testing.T) {
+	msp := mocks.NewSyncProducer(t, nil)
+	p := producer.Producer{SyncProducer: msp}
+
+	msg, err := message.New("topic", "message")
+	require.NoError(t, err)
+
+	msp.ExpectSendMessageWithCheckerFunctionAndSucceed(func(val []byte) error {
+		exp := "\"message\""
+		if string(val) != exp {
+			return fmt.Errorf("expected: %s but got: %s", exp, val)
+		}
+		return nil
+	})
+	err = p.SendMessage(msg)
+	require.NoError(t, err)
+
+	msp.ExpectSendMessageAndFail(fmt.Errorf("cannot produce message"))
+	err = p.SendMessage(msg)
+	require.EqualError(t, err, "failed to send message: cannot produce message")
+}
+
+func TestSend(t *testing.T) {
+	msp := mocks.NewSyncProducer(t, nil)
+	p := producer.Producer{SyncProducer: msp}
+
+	msp.ExpectSendMessageAndSucceed()
+	err := p.Send("topic", "message")
+	require.NoError(t, err)
+
+	msp.ExpectSendMessageAndFail(fmt.Errorf("cannot produce message"))
+	err = p.Send("topic", "message")
+	require.EqualError(t, err, "failed to send message: cannot produce message")
+}

--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -37,10 +37,10 @@ func TestSend(t *testing.T) {
 	p := producer.Producer{SyncProducer: msp}
 
 	msp.ExpectSendMessageAndSucceed()
-	err := p.Send("topic", "message")
+	_, err := p.Send("topic", "message")
 	require.NoError(t, err)
 
 	msp.ExpectSendMessageAndFail(fmt.Errorf("cannot produce message"))
-	err = p.Send("topic", "message")
+	_, err = p.Send("topic", "message")
 	require.EqualError(t, err, "failed to send message: cannot produce message")
 }


### PR DESCRIPTION
This PR imports the `Producer` type and its methods from kafka-go.
Notes:
- the `Producer` embeds the `sarama.SyncProducer` type and shadows the `Send` method to use our `message.Message` type
- the context parameter has been removed from the `Send*` methods; it is not used outside the Heetch's business 
- the tests have been improved by using the [sarama.mocks package](https://github.com/Shopify/sarama/tree/master/mocks)
- some improvements on the `message` package

Fix #12 