### PR TITLE
handler: Migrate handlers collection

### DIFF
--- a/consumer/handler/collection.go
+++ b/consumer/handler/collection.go
@@ -1,0 +1,1 @@
+package handler

--- a/consumer/handler/collection.go
+++ b/consumer/handler/collection.go
@@ -2,8 +2,6 @@ package handler
 
 import (
 	"sync"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // A Collection is set of Handler types, keyed by topic. Only one
@@ -15,8 +13,6 @@ import (
 // safe to use in concurrent code.
 type Collection struct {
 	sync.RWMutex
-
-	logger   *logrus.Entry
 	handlers map[string]Handler
 }
 

--- a/consumer/handler/collection.go
+++ b/consumer/handler/collection.go
@@ -1,1 +1,60 @@
 package handler
+
+import (
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// A Collection is set of Handler types, keyed by topic. Only one
+// handler may exists in a Collection per topic, but any number of
+// topics may be contained in the Collection. The handler for a topic
+// can be added via Set, and retrieved via Get. It is not currently
+// possible to remove a topic. Additionally the set of all topics with
+// handlers can be returned via the Topics function. These actions are
+// safe to use in concurrent code.
+type Collection struct {
+	sync.RWMutex
+
+	logger   *logrus.Entry
+	handlers map[string]Handler
+}
+
+// Get returns the Handler associated with a given topic, and a
+// Boolean value indicating if the topic was found at all. It is safe
+// to use Get from concurrent code.
+func (h *Collection) Get(topic string) (handler Handler, ok bool) {
+	h.RLock()
+	handler, ok = h.handlers[topic]
+	h.RUnlock()
+	return
+}
+
+// Topics returns a slice of all the topic names for which the
+// Collection contains a Handler. It is safe to use Topics from
+// concurrent code.
+func (h *Collection) Topics() []string {
+	h.RLock()
+	i := 0
+	count := len(h.handlers)
+	topics := make([]string, count)
+	for t := range h.handlers {
+		topics[i] = t
+		i++
+	}
+	h.RUnlock()
+	return topics
+}
+
+// Set associates the given Handler to the given Topic within the
+// collection.  If a Handler was already associated with the Topic,
+// then that association will be lost and replaced by the new one.  It
+// is safe to use Set from concurrent code.
+func (h *Collection) Set(topic string, handler Handler) {
+	h.Lock()
+	if h.handlers == nil {
+		h.handlers = make(map[string]Handler)
+	}
+	h.handlers[topic] = handler
+	h.Unlock()
+}

--- a/consumer/handler/collection_test.go
+++ b/consumer/handler/collection_test.go
@@ -1,29 +1,47 @@
 package handler_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/heetch/felice/consumer/handler"
+	"github.com/heetch/felice/message"
 	"github.com/stretchr/testify/require"
 )
+
+type testHandler struct {
+	ID int
+}
+
+func (th *testHandler) HandleMessage(m *message.Message) error {
+	return fmt.Errorf("%d", th.ID)
+}
 
 // The Get and Set functions on the Collection type manage a uniqe set
 // of associations between Topics and Handlers.
 func TestCollectionGetSet(t *testing.T) {
-	type testcase struct {
+	type testCase struct {
 		Topic   string
 		Handler handler.Handler
 		OK      bool
 	}
+
+	th1 := &testHandler{ID: 1}
+
 	setups := []struct {
 		Name     string
 		Handlers map[string]handler.Handler
-		Tests    []testcase
+		Tests    []testCase
 	}{
 		{
 			Name:     "Get from an empty Collection",
 			Handlers: make(map[string]handler.Handler),
-			Tests:    []testcase{{Topic: "Shoe", Handler: nil, OK: false}},
+			Tests:    []testCase{{Topic: "Shoe", Handler: nil, OK: false}},
+		},
+		{
+			Name:     "Set and Get the same Topic's handler",
+			Handlers: map[string]handler.Handler{"Shoe": th1},
+			Tests:    []testCase{{Topic: "Shoe", Handler: th1, OK: true}},
 		},
 	}
 
@@ -37,7 +55,8 @@ func TestCollectionGetSet(t *testing.T) {
 				h, ok := c.Get(tc.Topic)
 				if tc.OK {
 					require.True(t, ok)
-					require.Equal(t, tc.Handler, h)
+					msg := &message.Message{}
+					require.Equal(t, tc.Handler.HandleMessage(msg), h.HandleMessage(msg))
 				} else {
 					require.False(t, tc.OK)
 				}

--- a/consumer/handler/collection_test.go
+++ b/consumer/handler/collection_test.go
@@ -1,0 +1,49 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/heetch/felice/consumer/handler"
+	"github.com/stretchr/testify/require"
+)
+
+// The Get and Set functions on the Collection type manage a uniqe set
+// of associations between Topics and Handlers.
+func TestCollectionGetSet(t *testing.T) {
+	type testcase struct {
+		Topic   string
+		Handler handler.Handler
+		OK      bool
+	}
+	setups := []struct {
+		Name     string
+		Handlers map[string]handler.Handler
+		Tests    []testcase
+	}{
+		{
+			Name:     "Get from an empty Collection",
+			Handlers: make(map[string]handler.Handler),
+			Tests:    []testcase{{Topic: "Shoe", Handler: nil, OK: false}},
+		},
+	}
+
+	for _, s := range setups {
+		t.Run(s.Name, func(t *testing.T) {
+			c := &handler.Collection{}
+			for k, v := range s.Handlers {
+				c.Set(k, v)
+			}
+			for _, tc := range s.Tests {
+				h, ok := c.Get(tc.Topic)
+				if tc.OK {
+					require.True(t, ok)
+					require.Equal(t, tc.Handler, h)
+				} else {
+					require.False(t, tc.OK)
+				}
+			}
+
+		})
+	}
+
+}

--- a/consumer/handler/collection_test.go
+++ b/consumer/handler/collection_test.go
@@ -93,6 +93,11 @@ func TestCollectionTopics(t *testing.T) {
 			Topics:      nil,
 			Expectation: []string{},
 		},
+		{
+			Name:        "One topic",
+			Topics:      []string{"Shoe"},
+			Expectation: []string{"Shoe"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/consumer/handler/collection_test.go
+++ b/consumer/handler/collection_test.go
@@ -98,6 +98,11 @@ func TestCollectionTopics(t *testing.T) {
 			Topics:      []string{"Shoe"},
 			Expectation: []string{"Shoe"},
 		},
+		{
+			Name:        "Multiple topics",
+			Topics:      []string{"Shoe", "Fruit"},
+			Expectation: []string{"Shoe", "Fruit"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/consumer/handler/collection_test.go
+++ b/consumer/handler/collection_test.go
@@ -27,29 +27,43 @@ func TestCollectionGetSet(t *testing.T) {
 	}
 
 	th1 := &testHandler{ID: 1}
+	th2 := &testHandler{ID: 2}
 
 	setups := []struct {
 		Name     string
-		Handlers map[string]handler.Handler
+		Handlers []map[string]handler.Handler
 		Tests    []testCase
 	}{
 		{
 			Name:     "Get from an empty Collection",
-			Handlers: make(map[string]handler.Handler),
+			Handlers: nil,
 			Tests:    []testCase{{Topic: "Shoe", Handler: nil, OK: false}},
 		},
 		{
 			Name:     "Set and Get the same Topic's handler",
-			Handlers: map[string]handler.Handler{"Shoe": th1},
+			Handlers: []map[string]handler.Handler{{"Shoe": th1}},
 			Tests:    []testCase{{Topic: "Shoe", Handler: th1, OK: true}},
+		},
+		{
+			Name: "Overwite topic association",
+			Handlers: []map[string]handler.Handler{
+				{"Shoe": th1},
+				// The association with th2 should
+				// overwrite the association with th1.
+				{"Shoe": th2},
+			},
+			Tests: []testCase{{Topic: "Shoe", Handler: th2, OK: true}},
 		},
 	}
 
 	for _, s := range setups {
 		t.Run(s.Name, func(t *testing.T) {
 			c := &handler.Collection{}
-			for k, v := range s.Handlers {
-				c.Set(k, v)
+			// We apply iterations of handlers in order
+			for _, hi := range s.Handlers {
+				for k, v := range hi {
+					c.Set(k, v)
+				}
 			}
 			for _, tc := range s.Tests {
 				h, ok := c.Get(tc.Topic)


### PR DESCRIPTION
This PR fixes: #9 

I have taken the following steps:
- Import the `Handlers` struct from kafka-go
- Rename it "Collection"
- Remove logging and metric functionality (this is too kafka-go specific).
- Bring test coverage up to 100%