### PR TITLE
Import consumer from Kafka-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,6 +13,14 @@
   version = "v1.19.0"
 
 [[projects]]
+  digest = "1:526d64d0a3ac6c24875724a9355895be56a21f89a5d3ab5ba88d91244269a7d8"
+  name = "github.com/bsm/sarama-cluster"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c618e605e15c0d7535f6c96ff8efbb0dba4fd66c"
+  version = "v2.1.15"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -112,6 +120,7 @@
   input-imports = [
     "github.com/Shopify/sarama",
     "github.com/Shopify/sarama/mocks",
+    "github.com/bsm/sarama-cluster",
     "github.com/pkg/errors",
     "github.com/satori/go.uuid",
     "github.com/stretchr/testify/require",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,6 +36,10 @@
   name = "github.com/Shopify/sarama"
   version = "1.16.0"
 
+[[constraint]]
+  name = "github.com/bsm/sarama-cluster"
+  version = "2.1.12"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -100,6 +100,15 @@ func (c *Consumer) Serve(clientID string, addrs ...string) error {
 	return err
 }
 
+// Stop the consumer.
+func (c *Consumer) Stop() error {
+	close(c.quit)
+	defer c.wg.Wait()
+
+	err := c.consumer.Close()
+	return errors.Wrap(err, "failed to close the consumer properly")
+}
+
 func (c *Consumer) handlePartitions(ch <-chan cluster.PartitionConsumer) error {
 	for {
 		select {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -16,3 +16,25 @@ type Consumer struct {
 	quit          chan struct{}
 	RetryInterval time.Duration
 }
+
+// Handle registers the handler for the given topic.
+// Handle must be called before Serve.
+func (c *Consumer) Handle(topic string, h handler.Handler) {
+	c.setup()
+
+	c.handlers.Set(topic, h)
+}
+
+func (c *Consumer) setup() {
+	if c.handlers == nil {
+		c.handlers = &handler.Collection{}
+	}
+
+	if c.quit == nil {
+		c.quit = make(chan struct{})
+	}
+
+	if c.RetryInterval == 0 {
+		c.RetryInterval = time.Second
+	}
+}

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -21,7 +21,7 @@ type Consumer struct {
 	wg            sync.WaitGroup
 	quit          chan struct{}
 	RetryInterval time.Duration
-	metrics       MetricsHook
+	Metrics       MetricsHook
 }
 
 // Handle registers the handler for the given topic.
@@ -44,11 +44,6 @@ func (c *Consumer) setup() {
 	if c.RetryInterval == 0 {
 		c.RetryInterval = time.Second
 	}
-}
-
-// SetMetricsHook registers a MetricsHook on the Consumer that will be invoked with datas about the handled messages.
-func (c *Consumer) SetMetricsHook(mh MetricsHook) {
-	c.metrics = mh
 }
 
 func newClusterConfig(clientID string) *cluster.Config {
@@ -143,8 +138,8 @@ func (c *Consumer) handleMessages(ch <-chan *sarama.ConsumerMessage, offset offs
 			err := h.(handler.Handler).HandleMessage(m)
 			if err == nil {
 				offset.MarkOffset(msg, "")
-				if c.metrics != nil {
-					c.metrics.Reports(*m, map[string]string{
+				if c.Metrics != nil {
+					c.Metrics.Reports(*m, map[string]string{
 						"attempts":        strconv.Itoa(attempts),
 						"msgOffset":       strconv.FormatInt(msg.Offset, 10),
 						"remainingOffset": strconv.FormatInt(max.HighWaterMarkOffset()-msg.Offset, 10),

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -21,7 +21,7 @@ type Consumer struct {
 	wg            sync.WaitGroup
 	quit          chan struct{}
 	RetryInterval time.Duration
-	Metrics       MetricsHook
+	Metrics       MetricsReporter
 }
 
 // Handle registers the handler for the given topic.
@@ -139,7 +139,7 @@ func (c *Consumer) handleMessages(ch <-chan *sarama.ConsumerMessage, offset offs
 			if err == nil {
 				offset.MarkOffset(msg, "")
 				if c.Metrics != nil {
-					c.Metrics.Reports(*m, map[string]string{
+					c.Metrics.Report(*m, map[string]string{
 						"attempts":        strconv.Itoa(attempts),
 						"msgOffset":       strconv.FormatInt(msg.Offset, 10),
 						"remainingOffset": strconv.FormatInt(max.HighWaterMarkOffset()-msg.Offset, 10),
@@ -172,10 +172,10 @@ func (c *Consumer) convertMessage(cm *sarama.ConsumerMessage) *message.Message {
 	return &msg
 }
 
-// MetricsHook is a interface that can be passed to set metrics hook to receive metrics
+// MetricsReporter is a interface that can be passed to set metrics hook to receive metrics
 // from the consumer as it handles messages.
-type MetricsHook interface {
-	Reports(message.Message, map[string]string)
+type MetricsReporter interface {
+	Report(message.Message, map[string]string)
 }
 
 type offsetStash interface {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -1,13 +1,19 @@
 package consumer
 
 import (
+	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/Shopify/sarama"
 	cluster "github.com/bsm/sarama-cluster"
 	"github.com/heetch/felice/consumer/handler"
+	"github.com/heetch/felice/message"
+	"github.com/pkg/errors"
 )
 
+// Consumer is a Kafka consumer.
 type Consumer struct {
 	consumer      *cluster.Consumer
 	config        *cluster.Config
@@ -15,6 +21,7 @@ type Consumer struct {
 	wg            sync.WaitGroup
 	quit          chan struct{}
 	RetryInterval time.Duration
+	metrics       MetricsHook
 }
 
 // Handle registers the handler for the given topic.
@@ -37,4 +44,135 @@ func (c *Consumer) setup() {
 	if c.RetryInterval == 0 {
 		c.RetryInterval = time.Second
 	}
+}
+
+// SetMetricsHook registers a MetricsHook on the Consumer that will be invoked with datas about the handled messages.
+func (c *Consumer) SetMetricsHook(mh MetricsHook) {
+	c.metrics = mh
+}
+
+// Serve runs the consumer and listens for new messages on the given topics.
+func (c *Consumer) Serve(clientID string, addrs ...string) error {
+	c.setup()
+
+	config := cluster.NewConfig()
+	config.ClientID = clientID
+	config.Consumer.Return.Errors = true
+	// Specify that we are using at least Kafka v1.0
+	config.Version = sarama.V1_0_0_0
+	// Distribute load across instances using round robin strategy
+	config.Group.PartitionStrategy = cluster.StrategyRoundRobin
+	// One chan per partition instead of default multiplexing behaviour.
+	config.Group.Mode = cluster.ConsumerModePartitions
+	c.config = config
+	topics := c.handlers.Topics()
+
+	consumerGroup := fmt.Sprintf("%s-consumer-group", clientID)
+	var err error
+	c.consumer, err = cluster.NewConsumer(
+		addrs,
+		consumerGroup,
+		topics,
+		config)
+	if err != nil {
+		// Note: this kind of error comparison is weird, but
+		// it's possible because sarama defines the KError
+		// type as an int16 that supports the error interface.
+		if kerr, ok := err.(sarama.KError); ok && kerr == sarama.ErrConsumerCoordinatorNotAvailable {
+			// We'll add some additional context
+			// information.  This issue comes from the
+			// RefreshCoordinator call inside sarama, but
+			// it's not reporting the root cause, sadly.
+			//
+			// Even with this information it's rather an
+			// annoying little issue.
+			err = errors.Wrap(err, "__consumer_offsets topic doesn't yet exist, either because no client has yet requested an offset, or because this consumer group is not yet functioning at startup or after rebalancing.")
+		}
+		return errors.Wrap(err, fmt.Sprintf("failed to create a consumer for topics %+v in consumer group %q", topics, consumerGroup))
+	}
+
+	err = c.handlePartitions(c.consumer.Partitions())
+	return err
+}
+
+func (c *Consumer) handlePartitions(ch <-chan cluster.PartitionConsumer) error {
+	for {
+		select {
+		case part, ok := <-ch:
+			if !ok {
+				return fmt.Errorf("partition consumer channel closed")
+			}
+
+			c.wg.Add(1)
+			go func(pc cluster.PartitionConsumer) {
+				defer c.wg.Done()
+
+				c.handleMessages(pc.Messages(), c.consumer, pc)
+			}(part)
+		case <-c.quit:
+			return nil
+		}
+	}
+}
+
+func (c *Consumer) handleMessages(ch <-chan *sarama.ConsumerMessage, offset offsetStash, max highWaterMarker) {
+	for msg := range ch {
+		var attempts int
+
+		for {
+			attempts++
+
+			m := c.convertMessage(msg)
+			// Note: The second returned value is not checked because we will never receive messages for a topic
+			// that it does not have a handler for.
+			h, _ := c.handlers.Get(msg.Topic)
+			err := h.(handler.Handler).HandleMessage(m)
+			if err == nil {
+				offset.MarkOffset(msg, "")
+				if c.metrics != nil {
+					c.metrics.Reports(*m, map[string]string{
+						"attempts":        strconv.Itoa(attempts),
+						"msgOffset":       strconv.FormatInt(msg.Offset, 10),
+						"remainingOffset": strconv.FormatInt(max.HighWaterMarkOffset()-msg.Offset, 10),
+					})
+				}
+				break
+			}
+
+			select {
+			case <-time.After(c.RetryInterval):
+			case <-c.quit:
+				return
+			}
+		}
+	}
+}
+
+func (c *Consumer) convertMessage(cm *sarama.ConsumerMessage) *message.Message {
+	var msg message.Message
+	if cm.Key != nil {
+		msg.Key = string(cm.Key)
+	}
+
+	msg.Topic = cm.Topic
+	msg.ProducedAt = cm.Timestamp
+	msg.Offset = cm.Offset
+	msg.Partition = cm.Partition
+	msg.Body = cm.Value
+
+	return &msg
+}
+
+// MetricsHook is a interface that can be passed to set metrics hook to receive metrics
+// from the consumer as it handles messages.
+type MetricsHook interface {
+	Reports(message.Message, map[string]string)
+}
+
+type offsetStash interface {
+	MarkOffset(msg *sarama.ConsumerMessage, metadata string)
+}
+
+type highWaterMarker interface {
+	HighWaterMarkOffset() int64
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -1,0 +1,18 @@
+package consumer
+
+import (
+	"sync"
+	"time"
+
+	cluster "github.com/bsm/sarama-cluster"
+	"github.com/heetch/felice/consumer/handler"
+)
+
+type Consumer struct {
+	consumer      *cluster.Consumer
+	config        *cluster.Config
+	handlers      *handler.Collection
+	wg            sync.WaitGroup
+	quit          chan struct{}
+	RetryInterval time.Duration
+}

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -166,6 +166,9 @@ func TestConsumerHandleMessagesMetricsReporting(t *testing.T) {
 				require.Equal(t, "topic", msg.Topic)
 				require.EqualValues(t, "body", msg.Body)
 				require.EqualValues(t, "key", msg.Key)
+				require.Equal(t, "1", meta["attempts"])
+				require.Equal(t, "1", meta["msgOffset"])
+				require.Equal(t, "0", meta["remainingOffset"])
 			}
 		},
 	}
@@ -225,5 +228,5 @@ type mockHighWaterMarker struct {
 
 func (m *mockHighWaterMarker) HighWaterMarkOffset() int64 {
 	m.HighWaterMarkOffsetCount++
-	return 0
+	return int64(m.HighWaterMarkOffsetCount)
 }

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -160,6 +160,16 @@ func TestConvertMessage(t *testing.T) {
 	require.Equal(t, sm.Partition, msg.Partition)
 }
 
+// Consumer.newClusterConfig create a new configuration for the cluster.
+func TestNewClusterConfig(t *testing.T) {
+	c := newClusterConfig("test")
+	require.Equal(t, "test", c.ClientID)
+	require.True(t, c.Consumer.Return.Errors)
+	require.Equal(t, sarama.V1_0_0_0, c.Version)
+	require.Equal(t, cluster.StrategyRoundRobin, c.Group.PartitionStrategy)
+	require.Equal(t, cluster.ConsumerModePartitions, c.Group.Mode)
+}
+
 // The mockOffsetStash implements the OffsetStash interface for test
 // purposes.
 type mockOffsetStash struct {

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -133,7 +133,7 @@ func TestConsumerHandleMessagesMetricsReporting(t *testing.T) {
 	mos := &mockOffsetStash{}
 	c.handleMessages(ch, mos, hwm)
 
-	require.Equal(t, 1, mmh.ReportsCount)
+	require.Equal(t, 1, mmh.ReportCount)
 }
 
 // Consumer.convertMessage converts a sarama.ConsumerMessage into our
@@ -261,17 +261,17 @@ func (pc *PartitionConsumerMock) ResetOffset(offset int64, metadata string) {}
 
 // metricsHook implements the MetricsHook interface for testing purposes
 type metricsHook struct {
-	ReportsCount int
-	t            *testing.T
-	testCase     func(msg message.Message, metadatas map[string]string) (string, func(*testing.T))
+	ReportCount int
+	t           *testing.T
+	testCase    func(msg message.Message, metadatas map[string]string) (string, func(*testing.T))
 }
 
-// Reports counts how many times it has been called, and executes any
+// Report counts how many times it has been called, and executes any
 // testCase that has been added to the metricsHook.  This allows us to
 // reuse the metricsHook type every time we want to make assertions
 // about the information it has been provided.
-func (mmh *metricsHook) Reports(msg message.Message, metadatas map[string]string) {
-	mmh.ReportsCount++
+func (mmh *metricsHook) Report(msg message.Message, metadatas map[string]string) {
+	mmh.ReportCount++
 	mmh.t.Run(mmh.testCase(msg, metadatas))
 }
 

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -1,0 +1,24 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/heetch/felice/message"
+)
+
+type testHandler struct{}
+
+func (h *testHandler) HandleMessage(m *message.Message) error {
+	return nil
+}
+
+func TestHandle(t *testing.T) {
+	c := &Consumer{}
+	c.Handle("topic", &testHandler{})
+
+	res, ok := c.handlers.Get("topic")
+	require.True(t, ok)
+	require.NotNil(t, res)
+}

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -12,20 +12,7 @@ import (
 	"github.com/heetch/felice/message"
 )
 
-type testHandler struct {
-	t         *testing.T
-	testCase  func(*message.Message) (string, func(t *testing.T))
-	CallCount int
-}
-
-func (h *testHandler) HandleMessage(m *message.Message) error {
-	h.CallCount++
-	if h.testCase != nil {
-		h.t.Run(h.testCase(m))
-	}
-	return nil
-}
-
+// Consumer.Handle registers a handler for a topic.
 func TestHandle(t *testing.T) {
 	c := &Consumer{}
 	c.Handle("topic", &testHandler{})
@@ -35,55 +22,7 @@ func TestHandle(t *testing.T) {
 	require.NotNil(t, res)
 }
 
-// PartitionConsumerMock implements the sarama's PartitionConsumer interface for testing purposes.
-// The sarama library already defines a mock for it but we can't use it because it doesn't allow a partition consumer
-// to be created in such a way that you can push messages to it without creating the expectation that ConsumePartition will be called.
-type PartitionConsumerMock struct {
-	MessagesCount int
-	ch            chan *sarama.ConsumerMessage
-}
-
-func (pc *PartitionConsumerMock) Messages() <-chan *sarama.ConsumerMessage {
-	pc.MessagesCount++
-	if pc.ch == nil {
-		pc.ch = make(chan *sarama.ConsumerMessage)
-	}
-	close(pc.ch)
-	return pc.ch
-}
-
-func (pc *PartitionConsumerMock) AsyncClose() {
-
-}
-
-func (pc *PartitionConsumerMock) Close() error {
-	return nil
-}
-
-func (pc *PartitionConsumerMock) Errors() <-chan *sarama.ConsumerError {
-	return nil
-}
-
-func (pc *PartitionConsumerMock) HighWaterMarkOffset() int64 {
-	return 0
-}
-
-func (pc *PartitionConsumerMock) Topic() string {
-	return ""
-}
-
-func (pc *PartitionConsumerMock) Partition() int32 {
-	return 0
-}
-
-func (pc *PartitionConsumerMock) InitialOffset() int64 {
-	return 0
-}
-
-func (pc *PartitionConsumerMock) MarkOffset(offset int64, metadata string) {}
-
-func (pc *PartitionConsumerMock) ResetOffset(offset int64, metadata string) {}
-
+// Consumer.handlePartitions exits when we close the channel of PartitionConsumers
 func TestConsumerHandlePartitionsOnClosedChannel(t *testing.T) {
 	c := Consumer{}
 	ch := make(chan cluster.PartitionConsumer)
@@ -93,6 +32,7 @@ func TestConsumerHandlePartitionsOnClosedChannel(t *testing.T) {
 	require.EqualError(t, err, "partition consumer channel closed")
 }
 
+// Consumer.handlePartitions exits when we send something on the Quit channel
 func TestConsumerHandlePartitionsWithQuit(t *testing.T) {
 	c := Consumer{}
 	ch := make(chan cluster.PartitionConsumer)
@@ -103,6 +43,8 @@ func TestConsumerHandlePartitionsWithQuit(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// Consumer.handlePartitions provides a channel of messages, from each
+// PartitionConsumer, to the handleMessages function.
 func TestConsumerHandlePartitions(t *testing.T) {
 	c := Consumer{}
 	ch := make(chan cluster.PartitionConsumer, 1)
@@ -116,6 +58,8 @@ func TestConsumerHandlePartitions(t *testing.T) {
 	require.Equal(t, 1, pcm.MessagesCount)
 }
 
+// Consumer.handleMessages calls the per-topic Handler for each
+// message that arrives.
 func TestConsumerHandleMessages(t *testing.T) {
 	c := Consumer{}
 	handler := &testHandler{
@@ -146,17 +90,9 @@ func TestConsumerHandleMessages(t *testing.T) {
 	require.Equal(t, 1, handler.CallCount)
 }
 
-type metricsHook struct {
-	ReportsCount int
-	t            *testing.T
-	testCase     func(msg message.Message, metadatas map[string]string) (string, func(*testing.T))
-}
-
-func (mmh *metricsHook) Reports(msg message.Message, metadatas map[string]string) {
-	mmh.ReportsCount++
-	mmh.t.Run(mmh.testCase(msg, metadatas))
-}
-
+// Consumer.handleMessages will send message data, and some associated
+// metadata to a to metrics hook function that has been provided to
+// the consumer via the Consumer.SetMetricsHook function.
 func TestConsumerHandleMessagesMetricsReporting(t *testing.T) {
 	c := Consumer{}
 	mmh := &metricsHook{
@@ -192,6 +128,8 @@ func TestConsumerHandleMessagesMetricsReporting(t *testing.T) {
 
 }
 
+// Consumer.convertMessage converts a sarama.ConsumerMessage into our
+// own message.Message type.
 func TestConvertMessage(t *testing.T) {
 	c := &Consumer{}
 	now := time.Now()
@@ -213,20 +151,137 @@ func TestConvertMessage(t *testing.T) {
 	require.Equal(t, sm.Partition, msg.Partition)
 }
 
+// The mockOffsetStash implements the OffsetStash interface for test
+// purposes.
 type mockOffsetStash struct {
 	MarkOffsetCount int
 }
 
+// MarkOffset will increment the offset on the message and keep count
+// of how many times it has been called.
 func (m *mockOffsetStash) MarkOffset(msg *sarama.ConsumerMessage, metadata string) {
 	m.MarkOffsetCount++
 	msg.Offset++
 }
 
+// The mockHighWaterMarker implements the highWaterMarker interface
+// for testing purposes.
 type mockHighWaterMarker struct {
 	HighWaterMarkOffsetCount int
 }
 
+// HighWaterMarkOffset is required by the highWaterMarker interface.
+// We count the number of times this function is called, and return
+// that number as its result.
 func (m *mockHighWaterMarker) HighWaterMarkOffset() int64 {
 	m.HighWaterMarkOffsetCount++
 	return int64(m.HighWaterMarkOffsetCount)
+}
+
+// PartitionConsumerMock implements the sarama's PartitionConsumer
+// interface for testing purposes.  The sarama library already defines
+// a mock for it but we can't use it because it doesn't allow a
+// partition consumer to be created in such a way that you can push
+// messages to it without creating the expectation that
+// ConsumePartition will be called.
+type PartitionConsumerMock struct {
+	MessagesCount int
+	ch            chan *sarama.ConsumerMessage
+}
+
+// Messages returns a channel of *sarama.ConsumerMessage. In our case
+// we close the channel before returning it, as this allows us to test
+// handlePartitions without invoking any behaviour of handleMessages
+// or indeed hitting an error because of a nil channel.
+func (pc *PartitionConsumerMock) Messages() <-chan *sarama.ConsumerMessage {
+	pc.MessagesCount++
+	if pc.ch == nil {
+		pc.ch = make(chan *sarama.ConsumerMessage)
+	}
+	close(pc.ch)
+	return pc.ch
+}
+
+// AsyncClose is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) AsyncClose() {}
+
+// Close is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) Close() error {
+	return nil
+}
+
+// Errors is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) Errors() <-chan *sarama.ConsumerError {
+	return nil
+}
+
+// HighWaterMarkOffset is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) HighWaterMarkOffset() int64 {
+	return 0
+}
+
+// Topic is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) Topic() string {
+	return ""
+}
+
+// Partition is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) Partition() int32 {
+	return 0
+}
+
+// InitialOffset is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) InitialOffset() int64 {
+	return 0
+}
+
+// MarkOffset is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) MarkOffset(offset int64, metadata string) {}
+
+// ResetOffset is required by the PartitionConsumer interface.
+func (pc *PartitionConsumerMock) ResetOffset(offset int64, metadata string) {}
+
+// metricsHook implements the MetricsHook interface for testing purposes
+type metricsHook struct {
+	ReportsCount int
+	t            *testing.T
+	testCase     func(msg message.Message, metadatas map[string]string) (string, func(*testing.T))
+}
+
+// Reports counts how many times it has been called, and executes any
+// testCase that has been added to the metricsHook.  This allows us to
+// reuse the metricsHook type every time we want to make assertions
+// about the information it has been provided.
+func (mmh *metricsHook) Reports(msg message.Message, metadatas map[string]string) {
+	mmh.ReportsCount++
+	mmh.t.Run(mmh.testCase(msg, metadatas))
+}
+
+// testHandler implements the handler.Handler interface for testing
+// purposes. It can be used to make assertions about the message
+// passed to HandleMessage.
+type testHandler struct {
+	t *testing.T
+	// A testCase is a function that returns a name to be passed
+	// as the first parameter of testing.T.Run and Curryed
+	// function that forms a closure over the message.Message
+	// provided and can then be passed as the 2nd parameter of
+	// testing.T.Run.
+	testCase  func(*message.Message) (string, func(t *testing.T))
+	CallCount int
+}
+
+// HandleMessage will keep a count of how many times it is called and,
+// if a testCase is set on the testHandler, it will run it with the
+// message that HandleMessage recieved, allowing us to make assertions
+// about the nature of that message.
+func (h *testHandler) HandleMessage(m *message.Message) error {
+	h.CallCount++
+	if h.testCase != nil {
+		// We use testing.T.Run because we can easily see that
+		// the testCase has been run by looking at the verbose
+		// output of go test.
+		h.t.Run(h.testCase(m))
+	}
+	return nil
 }

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -100,8 +100,8 @@ func TestConsumerHandleMessages(t *testing.T) {
 }
 
 // Consumer.handleMessages will send message data, and some associated
-// metadata to a to metrics hook function that has been provided to
-// the consumer via the Consumer.SetMetricsHook function.
+// metadata to a metrics hook function that has been provided to
+// the consumer via the Consumer.Metrics field.
 func TestConsumerHandleMessagesMetricsReporting(t *testing.T) {
 	c := Consumer{}
 	mmh := &metricsHook{
@@ -117,7 +117,7 @@ func TestConsumerHandleMessagesMetricsReporting(t *testing.T) {
 			}
 		},
 	}
-	c.SetMetricsHook(mmh)
+	c.Metrics = mmh
 	handler := &testHandler{}
 
 	c.Handle("topic", handler)
@@ -134,7 +134,6 @@ func TestConsumerHandleMessagesMetricsReporting(t *testing.T) {
 	c.handleMessages(ch, mos, hwm)
 
 	require.Equal(t, 1, mmh.ReportsCount)
-
 }
 
 // Consumer.convertMessage converts a sarama.ConsumerMessage into our

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -22,6 +22,15 @@ func TestHandle(t *testing.T) {
 	require.NotNil(t, res)
 }
 
+// Consumer.setup initialises important values on the consumer
+func TestSetUp(t *testing.T) {
+	c := &Consumer{}
+	c.setup()
+	require.NotNil(t, c.handlers)
+	require.NotNil(t, c.quit)
+	require.Equal(t, c.RetryInterval, time.Second)
+}
+
 // Consumer.handlePartitions exits when we close the channel of PartitionConsumers
 func TestConsumerHandlePartitionsOnClosedChannel(t *testing.T) {
 	c := Consumer{}

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"testing"
 
+	cluster "github.com/bsm/sarama-cluster"
 	"github.com/stretchr/testify/require"
 
 	"github.com/heetch/felice/message"
@@ -21,4 +22,18 @@ func TestHandle(t *testing.T) {
 	res, ok := c.handlers.Get("topic")
 	require.True(t, ok)
 	require.NotNil(t, res)
+}
+
+// PartitionConsumerMock implements the sarama's PartitionConsumer interface for testing purposes.
+// The sarama library already defines a mock for it but we can't use it because it doesn't allow a partition consumer
+// to be created in such a way that you can push messages to it without creating the expectation that ConsumePartition will be called.
+type PartitionConsumerMock struct{}
+
+func TestConsumerHandlePartitionsOnClosedChannel(t *testing.T) {
+	c := Consumer{}
+	ch := make(chan cluster.PartitionConsumer)
+
+	close(ch)
+	err := c.handlePartitions(ch)
+	require.EqualError(t, err, "partition consumer channel closed")
 }

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -3,6 +3,8 @@ package consumer
 import (
 	"testing"
 
+	"github.com/Shopify/sarama"
+
 	cluster "github.com/bsm/sarama-cluster"
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +29,51 @@ func TestHandle(t *testing.T) {
 // PartitionConsumerMock implements the sarama's PartitionConsumer interface for testing purposes.
 // The sarama library already defines a mock for it but we can't use it because it doesn't allow a partition consumer
 // to be created in such a way that you can push messages to it without creating the expectation that ConsumePartition will be called.
-type PartitionConsumerMock struct{}
+type PartitionConsumerMock struct {
+	MessagesCount int
+	ch            chan *sarama.ConsumerMessage
+}
+
+func (pc *PartitionConsumerMock) Messages() <-chan *sarama.ConsumerMessage {
+	pc.MessagesCount++
+	if pc.ch == nil {
+		pc.ch = make(chan *sarama.ConsumerMessage)
+	}
+	close(pc.ch)
+	return pc.ch
+}
+
+func (pc *PartitionConsumerMock) AsyncClose() {
+
+}
+
+func (pc *PartitionConsumerMock) Close() error {
+	return nil
+}
+
+func (pc *PartitionConsumerMock) Errors() <-chan *sarama.ConsumerError {
+	return nil
+}
+
+func (pc *PartitionConsumerMock) HighWaterMarkOffset() int64 {
+	return 0
+}
+
+func (pc *PartitionConsumerMock) Topic() string {
+	return ""
+}
+
+func (pc *PartitionConsumerMock) Partition() int32 {
+	return 0
+}
+
+func (pc *PartitionConsumerMock) InitialOffset() int64 {
+	return 0
+}
+
+func (pc *PartitionConsumerMock) MarkOffset(offset int64, metadata string) {}
+
+func (pc *PartitionConsumerMock) ResetOffset(offset int64, metadata string) {}
 
 func TestConsumerHandlePartitionsOnClosedChannel(t *testing.T) {
 	c := Consumer{}
@@ -36,4 +82,27 @@ func TestConsumerHandlePartitionsOnClosedChannel(t *testing.T) {
 	close(ch)
 	err := c.handlePartitions(ch)
 	require.EqualError(t, err, "partition consumer channel closed")
+}
+
+func TestConsumerHandlePartitionsWithQuit(t *testing.T) {
+	c := Consumer{}
+	ch := make(chan cluster.PartitionConsumer)
+	c.quit = make(chan struct{}, 1)
+
+	c.quit <- struct{}{}
+	err := c.handlePartitions(ch)
+	require.NoError(t, err)
+}
+
+func TestConsumerHandlePartitions(t *testing.T) {
+	c := Consumer{}
+	ch := make(chan cluster.PartitionConsumer, 1)
+
+	pcm := &PartitionConsumerMock{}
+	ch <- pcm
+	close(ch)
+	err := c.handlePartitions(ch)
+	require.EqualError(t, err, "partition consumer channel closed")
+	c.wg.Wait()
+	require.Equal(t, 1, pcm.MessagesCount)
 }


### PR DESCRIPTION
Fix #10.

Notes:
- the logging and metrics have been removed
- new MetricsHook interface that can be passed to receive metrics