### PR TITLE
Fix Produced-At format

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -68,7 +68,7 @@ func New(topic string, value interface{}, opts ...Option) (*Message, error) {
 		Topic: topic,
 		Headers: map[string]string{
 			"Message-Id":  id,
-			"Produced-At": time.Now().UTC().String(),
+			"Produced-At": time.Now().UTC().Format(time.RFC3339),
 		},
 	}
 


### PR DESCRIPTION
Fixes #21 

Simply change the format of the timestamp stored against the "Produced-At" header. 