### PR TITLE
Add godoc link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ![](https://raw.githubusercontent.com/heetch/felice/master/felice.png)
-[![Documentation](https://godoc.org/github.com/heetch/felice?status.svg)](http://godoc.org/github.com/heetch/felice) 
+
 # Felice
 [![Build Status](https://travis-ci.org/heetch/felice.svg?branch=master)](https://travis-ci.org/heetch/felice)
+[![Documentation](https://godoc.org/github.com/heetch/felice?status.svg)](http://godoc.org/github.com/heetch/felice) 
 ## What is Felice?
 Felice is a nascent, opinionated Kafka library for Go, in Go. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![](https://raw.githubusercontent.com/heetch/felice/master/felice.png)
+[![Documentation](https://godoc.org/github.com/heetch/felice?status.svg)](http://godoc.org/github.com/heetch/felice) 
 # Felice
 [![Build Status](https://travis-ci.org/heetch/felice.svg?branch=master)](https://travis-ci.org/heetch/felice)
 ## What is Felice?

--- a/consumer/doc.go
+++ b/consumer/doc.go
@@ -30,12 +30,11 @@
 // handlers. Serve itself will block until Consumer.Stop is called.
 // When Serve terminates it will return an error, which will be nil
 // under normal circumstances.
-// 
+//
 // Note that any calls to Consumer.Handle after
 // Consumer.Serve has been called will have no effect.
 //
-// Tweaking the consumer
-// --------------------------
+// Tweaking the consumer:
 // The first public member is the RetryInterval, a time.Duration that
 // controls how long the Felice consumer will wait before trying to
 // consume a message from Kafka that failed the first time around.


### PR DESCRIPTION
Add a link to the documentation on godoc in the README.md file (with a badge)