### PR TITLE
Export config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,128 +2,95 @@
 
 
 [[projects]]
-  digest = "1:b6957a1836b6d7e51e5a71391f5c08fa5d866f57e4ac425fa5f183d518a5657b"
   name = "github.com/Shopify/sarama"
   packages = [
     ".",
-    "mocks",
+    "mocks"
   ]
-  pruneopts = "UT"
   revision = "ec843464b50d4c8b56403ec9d589cf41ea30e722"
   version = "v1.19.0"
 
 [[projects]]
-  digest = "1:526d64d0a3ac6c24875724a9355895be56a21f89a5d3ab5ba88d91244269a7d8"
   name = "github.com/bsm/sarama-cluster"
   packages = ["."]
-  pruneopts = "UT"
   revision = "c618e605e15c0d7535f6c96ff8efbb0dba4fd66c"
   version = "v2.1.15"
 
 [[projects]]
-  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:1f0c7ab489b407a7f8f9ad16c25a504d28ab461517a971d341388a56156c1bd7"
   name = "github.com/eapache/go-resiliency"
   packages = ["breaker"]
-  pruneopts = "UT"
   revision = "ea41b0fad31007accc7f806884dcdf3da98b79ce"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:79f16588b5576b1b3cd90e48d2374cc9a1a8776862d28d8fd0f23b0e15534967"
   name = "github.com/eapache/go-xerial-snappy"
   packages = ["."]
-  pruneopts = "UT"
   revision = "776d5712da21bc4762676d614db1d8a64f4238b0"
 
 [[projects]]
-  digest = "1:444b82bfe35c83bbcaf84e310fb81a1f9ece03edfed586483c869e2c046aef69"
   name = "github.com/eapache/queue"
   packages = ["."]
-  pruneopts = "UT"
   revision = "44cc805cf13205b55f69e14bcb69867d1ae92f98"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
   name = "github.com/golang/snappy"
   packages = ["."]
-  pruneopts = "UT"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
-  digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"
   name = "github.com/pierrec/lz4"
   packages = [
     ".",
-    "internal/xxh32",
+    "internal/xxh32"
   ]
-  pruneopts = "UT"
   revision = "635575b42742856941dbc767b44905bb9ba083f6"
   version = "v2.0.7"
 
 [[projects]]
-  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c4556a44e350b50a490544d9b06e9fba9c286c21d6c0e47f54f3a9214597298c"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
-  pruneopts = "UT"
   revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
   branch = "master"
-  digest = "1:ff6b0586c0621a76832cf783eee58cbb9d9795d2ce8acbc199a4131db11c42a9"
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  pruneopts = "UT"
   revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
 
 [[projects]]
-  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require",
+    "require"
   ]
-  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/Shopify/sarama",
-    "github.com/Shopify/sarama/mocks",
-    "github.com/bsm/sarama-cluster",
-    "github.com/pkg/errors",
-    "github.com/satori/go.uuid",
-    "github.com/stretchr/testify/require",
-  ]
+  inputs-digest = "5ecbe79e872821e53f3cf64781b0715000699ccd2460a556a4fa3421a3a2a491"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -1,0 +1,29 @@
+package consumer
+
+import (
+	"github.com/Shopify/sarama"
+	cluster "github.com/bsm/sarama-cluster"
+)
+
+// Config is used to configure the Consumer.
+type Config struct {
+	cluster.Config
+	// here we will add Felice specific configuration.
+}
+
+// NewConfig creates a config with sane defaults.
+// The Sarama Cluster group mode will always be overwritten by the consumer
+// and thus cannot be changed, as the consumer is designed to use the ConsumerModePartitions mode.
+func NewConfig(clientID string) Config {
+	c := cluster.NewConfig()
+	c.ClientID = clientID
+	c.Consumer.Return.Errors = true
+	// Specify that we are using at least Kafka v1.0
+	c.Version = sarama.V1_0_0_0
+	// Distribute load across instances using round robin strategy
+	c.Group.PartitionStrategy = cluster.StrategyRoundRobin
+	// One chan per partition instead of default multiplexing behaviour.
+	c.Group.Mode = cluster.ConsumerModePartitions
+
+	return Config{Config: *c}
+}

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -1,6 +1,8 @@
 package consumer
 
 import (
+	"time"
+
 	"github.com/Shopify/sarama"
 	cluster "github.com/bsm/sarama-cluster"
 )
@@ -8,14 +10,21 @@ import (
 // Config is used to configure the Consumer.
 type Config struct {
 	cluster.Config
-	// here we will add Felice specific configuration.
+
+	// RetryInterval controls how long the Felice consumer will wait before trying to
+	// consume a message from Kafka that failed the first time around.
+	// The default value if 1 second.
+	RetryInterval time.Duration
 }
 
 // NewConfig creates a config with sane defaults.
 // The Sarama Cluster group mode will always be overwritten by the consumer
 // and thus cannot be changed, as the consumer is designed to use the ConsumerModePartitions mode.
 func NewConfig(clientID string) Config {
-	c := cluster.NewConfig()
+	var c Config
+
+	// Sarama Cluster configuration
+	c.Config = *cluster.NewConfig()
 	c.ClientID = clientID
 	c.Consumer.Return.Errors = true
 	// Specify that we are using at least Kafka v1.0
@@ -25,5 +34,8 @@ func NewConfig(clientID string) Config {
 	// One chan per partition instead of default multiplexing behaviour.
 	c.Group.Mode = cluster.ConsumerModePartitions
 
-	return Config{Config: *c}
+	// Felice consumer configuration
+	c.RetryInterval = 1 * time.Second
+
+	return c
 }

--- a/consumer/config_test.go
+++ b/consumer/config_test.go
@@ -1,0 +1,19 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/Shopify/sarama"
+	cluster "github.com/bsm/sarama-cluster"
+	"github.com/stretchr/testify/require"
+)
+
+// checks if NewConfig returns the right defaults.
+func TestNewConfig(t *testing.T) {
+	c := NewConfig("test")
+	require.Equal(t, "test", c.ClientID)
+	require.True(t, c.Consumer.Return.Errors)
+	require.Equal(t, sarama.V1_0_0_0, c.Version)
+	require.Equal(t, cluster.StrategyRoundRobin, c.Group.PartitionStrategy)
+	require.Equal(t, cluster.ConsumerModePartitions, c.Group.Mode)
+}

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -27,6 +27,16 @@ type clusterConsumer interface {
 // register per-topic handlers and, finally, call it's Serve method to
 // begin consuming messages.
 type Consumer struct {
+	// Metrics stores a type that implements the felice.MetricsReporter interface.
+	// If you provide an implementation, then it's Report function will be called every time
+	// a message is successfully handled.  The Report function will
+	// receive a copy of the message.Message that was handled, along with
+	// a map[string]string containing metrics about the handling of the
+	// message.  Currently we pass the following metrics: "attempts" (the
+	// number of attempts it took before the message was handled);
+	// "msgOffset" (the marked offset for the message on the topic); and
+	// "remainingOffset" (the difference between the high water mark and
+	// the current offset).
 	Metrics MetricsReporter
 	// If you wish to provide a different value for the Logger, you must do this prior to calling Serve.
 	Logger      *log.Logger
@@ -78,7 +88,7 @@ func (c *Consumer) Serve(config Config, addrs ...string) error {
 	c.config = &config
 	// Always make sure we are using the right group mode: One chan per partition instead of default multiplexing behaviour.
 	if c.config.Group.Mode != cluster.ConsumerModePartitions {
-		c.Logger.Println("Warning: config.Group.Mode cannot be changed. Value replaced by cluster.ConsumerModePartitions.")
+		c.Logger.Println("warning: config.Group.Mode cannot be changed. Value replaced by cluster.ConsumerModePartitions.")
 		c.config.Group.Mode = cluster.ConsumerModePartitions
 	}
 

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -27,8 +27,7 @@ type clusterConsumer interface {
 // register per-topic handlers and, finally, call it's Serve method to
 // begin consuming messages.
 type Consumer struct {
-	RetryInterval time.Duration
-	Metrics       MetricsReporter
+	Metrics MetricsReporter
 	// If you wish to provide a different value for the Logger, you must do this prior to calling Serve.
 	Logger      *log.Logger
 	newConsumer func(addrs []string, groupID string, topics []string, config *cluster.Config) (clusterConsumer, error)
@@ -59,9 +58,6 @@ func (c *Consumer) setup() {
 		c.quit = make(chan struct{})
 	}
 
-	if c.RetryInterval == 0 {
-		c.RetryInterval = time.Second
-	}
 	if c.newConsumer == nil {
 		c.newConsumer = func(addrs []string, groupID string, topics []string, config *cluster.Config) (clusterConsumer, error) {
 			cons, err := cluster.NewConsumer(addrs, groupID, topics, config)
@@ -175,7 +171,7 @@ func (c *Consumer) handleMessages(ch <-chan *sarama.ConsumerMessage, offset offs
 			}
 
 			select {
-			case <-time.After(c.RetryInterval):
+			case <-time.After(c.config.RetryInterval):
 			case <-c.quit:
 				c.Logger.Println("partition messages - closing" + logSuffix)
 				return

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -28,7 +28,7 @@ type clusterConsumer interface {
 // begin consuming messages.
 type Consumer struct {
 	// Metrics stores a type that implements the felice.MetricsReporter interface.
-	// If you provide an implementation, then it's Report function will be called every time
+	// If you provide an implementation, then its Report function will be called every time
 	// a message is successfully handled.  The Report function will
 	// receive a copy of the message.Message that was handled, along with
 	// a map[string]string containing metrics about the handling of the

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -133,7 +133,6 @@ func TestSetUp(t *testing.T) {
 	c.setup()
 	require.NotNil(t, c.handlers)
 	require.NotNil(t, c.quit)
-	require.Equal(t, c.RetryInterval, time.Second)
 }
 
 // Consumer.handlePartitions exits when we close the channel of PartitionConsumers

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -32,7 +32,7 @@ type TestLogger struct {
 // NewTestLogger constructs a test logger we can make assertions against
 func NewTestLogger(t *testing.T) *TestLogger {
 	tl := &TestLogger{
-		t:   t,
+		t: t,
 	}
 	tl.Logger = log.New(&tl.buf, "[Felice] ", log.LstdFlags)
 	return tl
@@ -275,16 +275,6 @@ func TestConvertMessage(t *testing.T) {
 	require.Equal(t, sm.Partition, msg.Partition)
 }
 
-// Consumer.newClusterConfig create a new configuration for the cluster.
-func TestNewClusterConfig(t *testing.T) {
-	c := newClusterConfig("test")
-	require.Equal(t, "test", c.ClientID)
-	require.True(t, c.Consumer.Return.Errors)
-	require.Equal(t, sarama.V1_0_0_0, c.Version)
-	require.Equal(t, cluster.StrategyRoundRobin, c.Group.PartitionStrategy)
-	require.Equal(t, cluster.ConsumerModePartitions, c.Group.Mode)
-}
-
 // The mockOffsetStash implements the OffsetStash interface for test
 // purposes.
 type mockOffsetStash struct {
@@ -367,6 +357,6 @@ func TestServeLogsErrorFromNewConsumer(t *testing.T) {
 	c.Handle("foo", handler.HandlerFunc(func(m *message.Message) error {
 		return nil
 	}))
-	err := c.Serve("foo")
+	err := c.Serve(NewConfig("some-id"), "foo")
 	require.Error(t, err)
 }

--- a/consumer/doc.go
+++ b/consumer/doc.go
@@ -1,4 +1,4 @@
-// Consumer is Felice's primary entrance point for receiving messages
+// Package consumer is Felice's primary entrance point for receiving messages
 // from a Kafka cluster.
 //
 // There is no special construction function for the Consumer
@@ -6,7 +6,7 @@
 // discuss them below.  Thus you construct a Consumer by the normal Go
 // means:
 //
-//    c := felice.Consumer{}
+//    var c felice.Consumer
 //
 // Once you've constructed a consumer you must add message handlers to
 // it.  This is done by calling the Consumer.Handle method.  Each time
@@ -23,7 +23,7 @@
 //    }))
 //
 // Once you've registered all your handlers you may call
-// Consumer.Serve. Serve requires a client ID and a slice of strings,
+// Consumer.Serve. Serve requires a configuration and a slice of strings,
 // each of which is the address of a Kafka broker to attempt to
 // communicate with. Serve will start a go routine for each partition
 // to consume messages and pass them to their per-topic
@@ -33,22 +33,4 @@
 //
 // Note that any calls to Consumer.Handle after
 // Consumer.Serve has been called will have no effect.
-//
-// Tweaking the consumer:
-// The first public member is the RetryInterval, a time.Duration that
-// controls how long the Felice consumer will wait before trying to
-// consume a message from Kafka that failed the first time around.
-// The default value if 1 second.
-//
-// The second public member is Metrics.  Metrics stores a type that
-// implements the felice.MetricsReporter interface.  If you provide an
-// implementation, then it's Report function will be called every time
-// a message is successfully handled.  The Report function will
-// receive a copy of the message.Message that was handled, along with
-// a map[string]string containing metrics about the handling of the
-// message.  Currently we pass the following metrics: "attempts" (the
-// number of attempts it took before the message was handled);
-// "msgOffset" (the marked offset for the message on the topic); and
-// "remainingOffset" (the difference between the high water mark and
-// the current offset).
 package consumer

--- a/producer/config.go
+++ b/producer/config.go
@@ -9,7 +9,7 @@ type Config struct {
 }
 
 // NewConfig creates a config with sane defaults.
-func NewConfig(clientID string) *Config {
+func NewConfig(clientID string) Config {
 	config := sarama.NewConfig()
 	config.Version = sarama.V1_0_0_0
 	config.ClientID = clientID
@@ -19,5 +19,5 @@ func NewConfig(clientID string) *Config {
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
 
-	return &Config{*config}
+	return Config{*config}
 }

--- a/producer/config.go
+++ b/producer/config.go
@@ -1,0 +1,22 @@
+package producer
+
+import "github.com/Shopify/sarama"
+
+// Config is used to configure the Producer.
+type Config struct {
+	sarama.Config
+}
+
+// NewConfig creates a config with sane defaults.
+func NewConfig(clientID string) *Config {
+	config := sarama.NewConfig()
+	config.Version = sarama.V1_0_0_0
+	config.ClientID = clientID
+	config.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message
+	config.Producer.Retry.Max = 3                    // Retry up to 3 times to produce the message
+	// required for the SyncProducer, see https://godoc.org/github.com/Shopify/sarama#SyncProducer
+	config.Producer.Return.Successes = true
+	config.Producer.Return.Errors = true
+
+	return &Config{*config}
+}

--- a/producer/config.go
+++ b/producer/config.go
@@ -5,6 +5,7 @@ import "github.com/Shopify/sarama"
 // Config is used to configure the Producer.
 type Config struct {
 	sarama.Config
+	// here we will add Felice specific configuration.
 }
 
 // NewConfig creates a config with sane defaults.

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -16,27 +16,13 @@ type Producer struct {
 // New creates a configured Producer.
 // This Producer is synchronous, this means that it will wait for all the replicas to
 // acknowledge the message.
-func New(clientID string, maxRetry int, addrs ...string) (*Producer, error) {
-	config := newSaramaConfiguration(clientID, maxRetry)
-	p, err := sarama.NewSyncProducer(addrs, config)
+func New(config Config, addrs ...string) (*Producer, error) {
+	p, err := sarama.NewSyncProducer(addrs, &config.Config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a producer")
 	}
 
 	return &Producer{SyncProducer: p}, nil
-}
-
-func newSaramaConfiguration(clientID string, maxRetry int) *sarama.Config {
-	config := sarama.NewConfig()
-	config.Version = sarama.V1_0_0_0
-	config.ClientID = clientID
-	config.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message
-	config.Producer.Retry.Max = maxRetry             // Retry up to maxRetry times to produce the message
-	// required for the SyncProducer, see https://godoc.org/github.com/Shopify/sarama#SyncProducer
-	config.Producer.Return.Successes = true
-	config.Producer.Return.Errors = true
-
-	return config
 }
 
 // Send creates and sends a message to Kafka synchronously.


### PR DESCRIPTION
This PR adds `producer.Config` and `consumer.Config`. These configurations must be created before using the Producer or the Consumer and passed to them.

This change allows the user to change the configuration as it wants before running the producer or consumer. The user has also access to the underlying Sarama and Sarama-Cluster configuration and can tweak it easily.
