### PR TITLE
Fix panicking

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -81,7 +81,7 @@ func (c *Consumer) setup() {
 		}
 	}
 
-	if c.retryStrategy == nil {
+	if c.config != nil && c.retryStrategy == nil {
 		// Note: the logic in handleMsg assumes that
 		// this does not terminate; be aware of that when changing
 		// this strategy.
@@ -101,13 +101,13 @@ func (c *Consumer) setup() {
 // When Serve terminates it will return an Error or nil to indicate
 // that it excited without error.
 func (c *Consumer) Serve(config Config, addrs ...string) error {
-	c.setup()
-
 	c.config = &config
 	err := c.validateConfig()
 	if err != nil {
 		return err
 	}
+
+	c.setup()
 
 	topics := c.handlers.Topics()
 

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -239,7 +239,8 @@ func (c *Consumer) handleMsg(msg *sarama.ConsumerMessage) (*Message, int) {
 		}
 		return m, attempts
 	}
-	panic("unreachable")
+	return nil, attempts
+
 }
 
 // MetricsReporter is an interface that can be passed to set metrics hook to receive metrics


### PR DESCRIPTION
This PR fixes #43.

The first one is in the `setup` method when trying to retrieve the `MaxRetryInterval` configuration when `c.config` is nil.

The second one is involved by fixing the first one: calling `setup` when `c.config` is nil won't create the `c.retryStrategy`. This ends with panic when using it in `retry.StartWithCancel`.
We should create the config before calling `setup` in the `Serve` method.

The third one is the `panic("unreachable")`, when sending SIGINT to the consumer, this piece of code is reachable. We should return a nil Message to close the consumer.