### PR TITLE
Rework consumer API

### DIFF
--- a/consumer/config.go
+++ b/consumer/config.go
@@ -1,6 +1,7 @@
 package consumer
 
 import (
+	"errors"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -62,4 +63,13 @@ func NewConfig(clientID string, addrs ...string) Config {
 	}
 
 	return c
+}
+
+// Validate validates the configuration.
+func (c Config) Validate() error {
+	if len(c.KafkaAddrs) == 0 {
+		return errors.New("felice: invalid configuration (broker addresses must not be empty)")
+	}
+
+	return c.Config.Validate()
 }

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -1,30 +1,56 @@
 package consumer
 
 import (
+	"io/ioutil"
+	"log"
 	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/heetch/felice/codec"
+	"gopkg.in/retry.v1"
 )
+
+// MetricsReporter is an interface that can be passed to set metrics hook to receive metrics
+// from the consumer as it handles messages.
+type MetricsReporter interface {
+	Report(Message, *Metrics)
+}
 
 // Config is used to configure the Consumer.
 type Config struct {
 	*sarama.Config
 
+	// KafkaAddrs holds kafka brokers addresses. There must be at least
+	// one entry in the slice.
+	// Default to localhost:9092.
+	KafkaAddrs []string
+
+	// Metrics stores a type that implements the MetricsReporter interface.
+	// If you provide an implementation, then its Report function will be called every time
+	// a message is successfully handled.  The Report function will
+	// receive a copy of the message that was handled, along with
+	// a map[string]string containing metrics about the handling of the
+	// message.  Currently we pass the following metrics: "attempts" (the
+	// number of attempts it took before the message was handled);
+	// "msgOffset" (the marked offset for the message on the topic); and
+	// "remainingOffset" (the difference between the high water mark and
+	// the current offset).
+	Metrics MetricsReporter
+	// If you wish to provide a different value for the Logger, you must do this prior to calling Consumer.Serve.
+	Logger *log.Logger
 	// MaxRetryInterval controls the maximum length of time that
 	// the Felice consumer will wait before trying to
 	// consume a message from Kafka that failed the first time around.
-	// The default value is 5 seconds.
+	// Default to 5 seconds.
 	MaxRetryInterval time.Duration
-
 	// Codec used to decode the message key. Defaults to codec.String.
 	KeyCodec codec.Codec
+
+	retryStrategy retry.Strategy
 }
 
 // NewConfig creates a config with sane defaults.
-// The Sarama Cluster group mode will always be overwritten by the consumer
-// and thus cannot be changed, as the consumer is designed to use the ConsumerModePartitions mode.
-func NewConfig(clientID string) Config {
+func NewConfig(clientID string, addrs ...string) Config {
 	var c Config
 
 	c.Config = sarama.NewConfig()
@@ -32,12 +58,29 @@ func NewConfig(clientID string) Config {
 	c.Consumer.Return.Errors = true
 	// Specify that we are using at least Kafka v1.0
 	c.Version = sarama.V1_0_0_0
-
 	// Distribute load across instances using round robin strategy
 	c.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
 
 	// Felice consumer configuration
+	c.KafkaAddrs = addrs
+	if c.KafkaAddrs == nil {
+		c.KafkaAddrs = []string{"localhost:9092"}
+	}
+
 	c.MaxRetryInterval = 5 * time.Second
 	c.KeyCodec = codec.String() // defaults to String
+
+	c.Logger = log.New(ioutil.Discard, "[Felice] ", log.LstdFlags)
+
+	// Note: the logic in handleMsg assumes that
+	// this does not terminate; be aware of that when changing
+	// this strategy.
+	c.retryStrategy = retry.Exponential{
+		Initial:  time.Millisecond,
+		Factor:   2,
+		MaxDelay: c.MaxRetryInterval,
+		Jitter:   true,
+	}
+
 	return c
 }

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -30,6 +30,7 @@ type Config struct {
 }
 
 // NewConfig creates a config with sane defaults.
+// Broker addresses defaults to localhost:9092.
 func NewConfig(clientID string, addrs ...string) Config {
 	var c Config
 

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -15,16 +15,16 @@ type Config struct {
 
 	// KafkaAddrs holds kafka brokers addresses. There must be at least
 	// one entry in the slice.
-	// Default to localhost:9092.
+	// The default value is "localhost:9092".
 	KafkaAddrs []string
 
 	// MaxRetryInterval controls the maximum length of time that
 	// the Felice consumer will wait before trying to
 	// consume a message from Kafka that failed the first time around.
-	// Default to 5 seconds.
+	// The default value is 5 seconds.
 	MaxRetryInterval time.Duration
 	// Codec used to decode the message key.
-	// Default to codec.String.
+	// The default value is codec.String.
 	KeyCodec codec.Codec
 
 	retryStrategy retry.Strategy
@@ -45,7 +45,7 @@ func NewConfig(clientID string, addrs ...string) Config {
 
 	// Felice consumer configuration
 	c.KafkaAddrs = addrs
-	if c.KafkaAddrs == nil {
+	if len(c.KafkaAddrs) == 0 {
 		c.KafkaAddrs = []string{"localhost:9092"}
 	}
 

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -1,20 +1,12 @@
 package consumer
 
 import (
-	"io/ioutil"
-	"log"
 	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/heetch/felice/codec"
 	"gopkg.in/retry.v1"
 )
-
-// MetricsReporter is an interface that can be passed to set metrics hook to receive metrics
-// from the consumer as it handles messages.
-type MetricsReporter interface {
-	Report(Message, *Metrics)
-}
 
 // Config is used to configure the Consumer.
 type Config struct {
@@ -25,25 +17,13 @@ type Config struct {
 	// Default to localhost:9092.
 	KafkaAddrs []string
 
-	// Metrics stores a type that implements the MetricsReporter interface.
-	// If you provide an implementation, then its Report function will be called every time
-	// a message is successfully handled.  The Report function will
-	// receive a copy of the message that was handled, along with
-	// a map[string]string containing metrics about the handling of the
-	// message.  Currently we pass the following metrics: "attempts" (the
-	// number of attempts it took before the message was handled);
-	// "msgOffset" (the marked offset for the message on the topic); and
-	// "remainingOffset" (the difference between the high water mark and
-	// the current offset).
-	Metrics MetricsReporter
-	// If you wish to provide a different value for the Logger, you must do this prior to calling Consumer.Serve.
-	Logger *log.Logger
 	// MaxRetryInterval controls the maximum length of time that
 	// the Felice consumer will wait before trying to
 	// consume a message from Kafka that failed the first time around.
 	// Default to 5 seconds.
 	MaxRetryInterval time.Duration
-	// Codec used to decode the message key. Defaults to codec.String.
+	// Codec used to decode the message key.
+	// Default to codec.String.
 	KeyCodec codec.Codec
 
 	retryStrategy retry.Strategy
@@ -69,8 +49,6 @@ func NewConfig(clientID string, addrs ...string) Config {
 
 	c.MaxRetryInterval = 5 * time.Second
 	c.KeyCodec = codec.String() // defaults to String
-
-	c.Logger = log.New(ioutil.Discard, "[Felice] ", log.LstdFlags)
 
 	// Note: the logic in handleMsg assumes that
 	// this does not terminate; be aware of that when changing

--- a/consumer/config_test.go
+++ b/consumer/config_test.go
@@ -27,10 +27,6 @@ func TestConfig(t *testing.T) {
 			MaxDelay: c.MaxRetryInterval,
 			Jitter:   true,
 		}, c.retryStrategy)
-
-		require.NotNil(t, c.Logger)
-
-		require.Equal(t, "[Felice] ", c.Logger.Prefix())
 	})
 
 	t.Run("With broker addrs", func(t *testing.T) {

--- a/consumer/config_test.go
+++ b/consumer/config_test.go
@@ -2,17 +2,40 @@ package consumer
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/retry.v1"
 )
 
-func TestNewConfig(t *testing.T) {
-	c := NewConfig("test")
-	require.Equal(t, "test", c.ClientID)
-	require.True(t, c.Consumer.Return.Errors)
-	require.Equal(t, sarama.V1_0_0_0, c.Version)
-	require.Equal(t, sarama.BalanceStrategyRoundRobin, c.Consumer.Group.Rebalance.Strategy)
+func TestConfig(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		c := NewConfig("client-id")
+		require.Equal(t, "client-id", c.ClientID)
+		require.True(t, c.Consumer.Return.Errors)
+		require.Equal(t, sarama.V1_0_0_0, c.Version)
+		require.Equal(t, sarama.BalanceStrategyRoundRobin, c.Consumer.Group.Rebalance.Strategy)
 
-	require.NotNil(t, c.KeyCodec)
+		require.Equal(t, 5*time.Second, c.MaxRetryInterval)
+		require.NotNil(t, c.KeyCodec)
+
+		require.Equal(t, []string{"localhost:9092"}, c.KafkaAddrs)
+		require.Equal(t, retry.Exponential{
+			Initial:  time.Millisecond,
+			Factor:   2,
+			MaxDelay: c.MaxRetryInterval,
+			Jitter:   true,
+		}, c.retryStrategy)
+
+		require.NotNil(t, c.Logger)
+
+		require.Equal(t, "[Felice] ", c.Logger.Prefix())
+	})
+
+	t.Run("With broker addrs", func(t *testing.T) {
+		c := NewConfig("client-id", "1.2.3.4:9092", "5.6.7.8:9092")
+		require.Equal(t, "client-id", c.ClientID)
+		require.Equal(t, []string{"1.2.3.4:9092", "5.6.7.8:9092"}, c.KafkaAddrs)
+	})
 }

--- a/consumer/config_test.go
+++ b/consumer/config_test.go
@@ -27,11 +27,25 @@ func TestConfig(t *testing.T) {
 			MaxDelay: c.MaxRetryInterval,
 			Jitter:   true,
 		}, c.retryStrategy)
+
+		require.NoError(t, c.Validate())
 	})
 
 	t.Run("With broker addrs", func(t *testing.T) {
 		c := NewConfig("client-id", "1.2.3.4:9092", "5.6.7.8:9092")
 		require.Equal(t, "client-id", c.ClientID)
 		require.Equal(t, []string{"1.2.3.4:9092", "5.6.7.8:9092"}, c.KafkaAddrs)
+
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("Without broker addrs", func(t *testing.T) {
+		c := Config{
+			Config: sarama.NewConfig(),
+		}
+
+		err := c.Validate()
+		require.Error(t, err)
+		require.Equal(t, "felice: invalid configuration (broker addresses must not be empty)", err.Error())
 	})
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -72,8 +72,7 @@ func (c *Consumer) Handle(topic string, converter MessageConverter, h Handler) {
 	c.Logger.Printf("Registered handler. topic=%q\n", topic)
 }
 
-// Serve runs the consumer and listens for new messages on the given
-// topics.
+// Serve runs the consumer and listens for new messages on the given topics.
 // Serve will block until it is instructed to stop, which you can achieve by calling Consumer.Stop.
 // When Serve terminates it will return an Error or nil to indicate that it exited without error.
 func (c *Consumer) Serve() error {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -14,11 +14,11 @@ import (
 )
 
 // Consumer is the structure used to consume messages from Kafka.
-// Having constructed a Consumer you should use its Handle method to
+// Having constructed a Consumer with New, you should use its Handle method to
 // register per-topic handlers and, finally, call it's Serve method to
 // begin consuming messages.
 type Consumer struct {
-	// Metrics stores a type that implements the felice.MetricsReporter interface.
+	// Metrics stores a type that implements the MetricsReporter interface.
 	// If you provide an implementation, then its Report function will be called every time
 	// a message is successfully handled.  The Report function will
 	// receive a copy of the message that was handled, along with
@@ -29,53 +29,47 @@ type Consumer struct {
 	// "remainingOffset" (the difference between the high water mark and
 	// the current offset).
 	Metrics MetricsReporter
-	// If you wish to provide a different value for the Logger, you must do this prior to calling Serve.
+
+	// Logger output defaults to ioutil.Discard.
+	// If you wish to provide a different value for the Logger, you must do this prior to calling Consumer.Serve.
 	Logger *log.Logger
 
-	consumer      sarama.ConsumerGroup
-	retryStrategy retry.Strategy
-	config        *Config
-	handlers      *collection
-	quit          chan struct{}
+	consumer sarama.ConsumerGroup
+	config   *Config
+	handlers *collection
+	quit     chan struct{}
+}
+
+// New returns a ready to use Consumer configured with sane defaults.
+// The passed Config shouldn't be nil otherwise a non nil error will be returned.
+func New(cfg *Config) (*Consumer, error) {
+	if cfg == nil {
+		return nil, errors.New("configuration must be not nil")
+	}
+
+	err := cfg.Config.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Consumer{
+		Logger: log.New(ioutil.Discard, "[Felice] ", log.LstdFlags),
+
+		config:   cfg,
+		handlers: new(collection),
+		quit:     make(chan struct{}),
+	}, nil
 }
 
 // Handle registers the handler for the given topic.
 // Handle must be called before Serve.
 func (c *Consumer) Handle(topic string, converter MessageConverter, h Handler) {
-	c.setup()
-
 	c.handlers.Set(topic, HandlerConfig{
 		Handler:   h,
 		Converter: converter,
 	})
 
 	c.Logger.Printf("Registered handler. topic=%q\n", topic)
-}
-
-func (c *Consumer) setup() {
-	if c.Logger == nil {
-		c.Logger = log.New(ioutil.Discard, "[Felice] ", log.LstdFlags)
-	}
-
-	if c.handlers == nil {
-		c.handlers = new(collection)
-	}
-
-	if c.quit == nil {
-		c.quit = make(chan struct{})
-	}
-
-	if c.config != nil && c.retryStrategy == nil {
-		// Note: the logic in handleMsg assumes that
-		// this does not terminate; be aware of that when changing
-		// this strategy.
-		c.retryStrategy = retry.Exponential{
-			Initial:  time.Millisecond,
-			Factor:   2,
-			MaxDelay: c.config.MaxRetryInterval,
-			Jitter:   true,
-		}
-	}
 }
 
 // Serve runs the consumer and listens for new messages on the given
@@ -90,8 +84,6 @@ func (c *Consumer) Serve(config Config, addrs ...string) error {
 	if err != nil {
 		return err
 	}
-
-	c.setup()
 
 	groupID := fmt.Sprintf("%s-consumer-group", c.config.ClientID)
 	c.consumer, err = sarama.NewConsumerGroup(addrs, groupID, c.config.Config)
@@ -166,11 +158,10 @@ func (c *Consumer) Stop() error {
 // handleMsg attempts to handle the message. It retries until the
 // message can be handled OK or the consumer is stopped.
 // It returns the message that was handled and the
-// number of attempts that it took, or
-// nil if the consumer was stopped.
+// number of attempts that it took, or nil if the consumer was stopped.
 func (c consumerGroupHandler) handleMsg(msg *sarama.ConsumerMessage, h HandlerConfig) (*Message, int) {
 	attempts := 0
-	for a := retry.StartWithCancel(c.consumer.retryStrategy, nil, c.consumer.quit); a.Next(); {
+	for a := retry.StartWithCancel(c.consumer.config.retryStrategy, nil, c.consumer.quit); a.Next(); {
 		if !a.More() {
 			// Note: we're assuming here that the retry
 			// strategy does not terminate except when
@@ -195,20 +186,6 @@ func (c consumerGroupHandler) handleMsg(msg *sarama.ConsumerMessage, h HandlerCo
 		return m, attempts
 	}
 	return nil, attempts
-}
-
-// MetricsReporter is an interface that can be passed to set metrics hook to receive metrics
-// from the consumer as it handles messages.
-type MetricsReporter interface {
-	Report(Message, *Metrics)
-}
-
-// Metrics contains information about message consumption for a given partition.
-type Metrics struct {
-	// Number of times the consumer tried to consume this message.
-	Attempts int
-	// Best effort information about the remaining unconsumed messages in the partition
-	RemainingOffset int64
 }
 
 // Message represents a message received from Kafka.
@@ -281,4 +258,18 @@ func (f *messageConverterV1) FromKafka(cm *sarama.ConsumerMessage) (*Message, er
 	msg.ID = msg.Headers["Message-Id"]
 
 	return &msg, nil
+}
+
+// MetricsReporter is an interface that can be passed to set metrics hook to receive metrics
+// from the consumer as it handles messages.
+type MetricsReporter interface {
+	Report(Message, *Metrics)
+}
+
+// Metrics contains information about message consumption for a given partition.
+type Metrics struct {
+	// Number of times the consumer tried to consume this message.
+	Attempts int
+	// Best effort information about the remaining unconsumed messages in the partition.
+	RemainingOffset int64
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -41,13 +41,8 @@ type Consumer struct {
 }
 
 // New returns a ready to use Consumer configured with sane defaults.
-// The passed Config shouldn't be nil otherwise a non nil error will be returned.
-func New(cfg *Config) (*Consumer, error) {
-	if cfg == nil {
-		return nil, errors.New("configuration must be not nil")
-	}
-
-	err := cfg.Config.Validate()
+func New(cfg Config) (*Consumer, error) {
+	err := cfg.Validate()
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +50,7 @@ func New(cfg *Config) (*Consumer, error) {
 	return &Consumer{
 		Logger: log.New(ioutil.Discard, "[Felice] ", log.LstdFlags),
 
-		config:   cfg,
+		config:   &cfg,
 		handlers: new(collection),
 		quit:     make(chan struct{}),
 	}, nil

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -73,20 +73,14 @@ func (c *Consumer) Handle(topic string, converter MessageConverter, h Handler) {
 }
 
 // Serve runs the consumer and listens for new messages on the given
-// topics.  You must provide it with unique clientID and the address
-// of one or more Kafka brokers.  Serve will block until it is
-// instructed to stop, which you can achieve by calling Consumer.Stop.
-// When Serve terminates it will return an Error or nil to indicate
-// that it exited without error.
-func (c *Consumer) Serve(config Config, addrs ...string) error {
-	c.config = &config
-	err := c.config.Validate()
-	if err != nil {
-		return err
-	}
+// topics.
+// Serve will block until it is instructed to stop, which you can achieve by calling Consumer.Stop.
+// When Serve terminates it will return an Error or nil to indicate that it exited without error.
+func (c *Consumer) Serve() error {
+	var err error
 
 	groupID := fmt.Sprintf("%s-consumer-group", c.config.ClientID)
-	c.consumer, err = sarama.NewConsumerGroup(addrs, groupID, c.config.Config)
+	c.consumer, err = sarama.NewConsumerGroup(c.config.KafkaAddrs, groupID, c.config.Config)
 	if err != nil {
 		// Note: this kind of error comparison is weird, but
 		// it's possible because sarama defines the KError

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -6,31 +6,22 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-
 	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
-	t.Run("OK", func(t *testing.T) {
-		c, err := New(newConfig())
-		require.NoError(t, err)
+	c, err := New(NewConfig("some-id"))
+	require.NoError(t, err)
 
-		require.NotNil(t, c.Logger)
-		require.NotNil(t, c.config)
-		require.NotNil(t, c.handlers)
-		require.NotNil(t, c.quit)
-	})
-
-	t.Run("NOK - nil Config", func(t *testing.T) {
-		_, err := New(nil)
-		require.Error(t, err)
-		require.Equal(t, "configuration must be not nil", err.Error())
-	})
+	require.NotNil(t, c.Logger)
+	require.NotNil(t, c.config)
+	require.NotNil(t, c.handlers)
+	require.NotNil(t, c.quit)
 }
 
 // Consumer.Handle registers a handler for a topic.
 func TestHandle(t *testing.T) {
-	c, _ := New(newConfig())
+	c, _ := New(NewConfig("some-id"))
 	c.Handle("topic", MessageConverterV1(NewConfig("")), &testHandler{})
 
 	res, ok := c.handlers.Get("topic")
@@ -49,7 +40,7 @@ func TestConsumerClaim(t *testing.T) {
 		topic: topic,
 	}
 
-	c, _ := New(newConfig())
+	c, _ := New(NewConfig("some-id"))
 	c.Logger = tl.Logger
 
 	handler := &testHandler{
@@ -108,7 +99,7 @@ func TestConsumerClaimMetricsReporting(t *testing.T) {
 			}
 		},
 	}
-	c, _ := New(newConfig())
+	c, _ := New(NewConfig("some-id"))
 	c.Metrics = mmh
 
 	handler := &testHandler{}
@@ -145,7 +136,7 @@ func TestConsumerClaimRetryOnError(t *testing.T) {
 		metricsCh <- metrics
 	}
 
-	c, _ := New(newConfig())
+	c, _ := New(NewConfig("some-id"))
 	c.Metrics = metricsReporterFunc(reportMetric)
 
 	type msgHandleReq struct {
@@ -249,7 +240,7 @@ func TestMessageConverterV1(t *testing.T) {
 
 // Test that Consumer.Handle emits log messages
 func TestHandleLogs(t *testing.T) {
-	c, _ := New(newConfig())
+	c, _ := New(NewConfig("some-id"))
 
 	tl := NewTestLogger(t)
 	c.Logger = tl.Logger

--- a/consumer/consumer_internal_test.go
+++ b/consumer/consumer_internal_test.go
@@ -10,22 +10,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNew(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		c, err := New(newConfig())
+		require.NoError(t, err)
+
+		require.NotNil(t, c.Logger)
+		require.NotNil(t, c.config)
+		require.NotNil(t, c.handlers)
+		require.NotNil(t, c.quit)
+	})
+
+	t.Run("NOK - nil Config", func(t *testing.T) {
+		_, err := New(nil)
+		require.Error(t, err)
+		require.Equal(t, "configuration must be not nil", err.Error())
+	})
+}
+
 // Consumer.Handle registers a handler for a topic.
 func TestHandle(t *testing.T) {
-	c := &Consumer{config: newConfig()}
+	c, _ := New(newConfig())
 	c.Handle("topic", MessageConverterV1(NewConfig("")), &testHandler{})
 
 	res, ok := c.handlers.Get("topic")
 	require.True(t, ok)
 	require.NotNil(t, res)
-}
-
-// Consumer.setup initialises important values on the consumer
-func TestSetUp(t *testing.T) {
-	c := &Consumer{config: newConfig()}
-	c.setup()
-	require.NotNil(t, c.handlers)
-	require.NotNil(t, c.quit)
 }
 
 // ConsumerClaim calls the per-topic Handler for each message that arrives.
@@ -39,10 +49,9 @@ func TestConsumerClaim(t *testing.T) {
 		topic: topic,
 	}
 
-	c := Consumer{
-		config: newConfig(),
-		Logger: tl.Logger,
-	}
+	c, _ := New(newConfig())
+	c.Logger = tl.Logger
+
 	handler := &testHandler{
 		t: t,
 		testCase: func(m *Message) (string, func(t *testing.T)) {
@@ -65,7 +74,7 @@ func TestConsumerClaim(t *testing.T) {
 	close(claim.ch)
 
 	groupHandler := consumerGroupHandler{
-		consumer: &c,
+		consumer: c,
 	}
 	groupHandler.ConsumeClaim(sess, claim)
 
@@ -86,7 +95,6 @@ func TestConsumerClaimMetricsReporting(t *testing.T) {
 		topic: topic,
 	}
 
-	c := Consumer{config: newConfig()}
 	mmh := &metricsHook{
 		t: t,
 		testCase: func(msg Message, meta *Metrics) (string, func(t *testing.T)) {
@@ -100,7 +108,9 @@ func TestConsumerClaimMetricsReporting(t *testing.T) {
 			}
 		},
 	}
+	c, _ := New(newConfig())
 	c.Metrics = mmh
+
 	handler := &testHandler{}
 
 	c.Handle(topic, MessageConverterV1(NewConfig("")), handler)
@@ -114,7 +124,7 @@ func TestConsumerClaimMetricsReporting(t *testing.T) {
 	close(claim.ch)
 
 	groupHandler := consumerGroupHandler{
-		consumer: &c,
+		consumer: c,
 	}
 	groupHandler.ConsumeClaim(sess, claim)
 
@@ -130,13 +140,12 @@ func TestConsumerClaimRetryOnError(t *testing.T) {
 		topic: topic,
 	}
 
-	c := Consumer{
-		config: newConfig(),
-	}
 	metricsCh := make(chan *Metrics)
 	reportMetric := func(m Message, metrics *Metrics) {
 		metricsCh <- metrics
 	}
+
+	c, _ := New(newConfig())
 	c.Metrics = metricsReporterFunc(reportMetric)
 
 	type msgHandleReq struct {
@@ -154,7 +163,7 @@ func TestConsumerClaimRetryOnError(t *testing.T) {
 	handleMessagesDone := make(chan struct{})
 
 	groupHandler := consumerGroupHandler{
-		consumer: &c,
+		consumer: c,
 	}
 	go func() {
 		defer close(handleMessagesDone)
@@ -240,11 +249,11 @@ func TestMessageConverterV1(t *testing.T) {
 
 // Test that Consumer.Handle emits log messages
 func TestHandleLogs(t *testing.T) {
+	c, _ := New(newConfig())
+
 	tl := NewTestLogger(t)
-	c := &Consumer{
-		config: newConfig(),
-		Logger: tl.Logger,
-	}
+	c.Logger = tl.Logger
+
 	c.Handle("foo", MessageConverterV1(NewConfig("")), HandlerFunc(func(m *Message) error {
 		return nil
 	}))

--- a/consumer/doc.go
+++ b/consumer/doc.go
@@ -1,12 +1,12 @@
 // Package consumer is Felice's primary entrance point for receiving messages
 // from a Kafka cluster.
 //
-// There is no special construction function for the Consumer
-// structure as all of its public members are optional, and we shall
-// discuss them below.  Thus you construct a Consumer by the normal Go
-// means:
+// The best way to create a Consumer is using the New function.
+// You have to pass a non nil Config otherwise New will return an error.
 //
-//    var c consumer.Consumer
+// Note: NewConfig returns a Config with sane defaults.
+//
+//    c, _ = New(NewConfig("client-id"))
 //
 // Once you've constructed a consumer you must add message handlers to
 // it.  This is done by calling the Consumer.Handle method.  Each time
@@ -22,11 +22,9 @@
 //        return nil // .. or return an actual error.
 //    }))
 //
-// Once you've registered all your handlers you may call
-// Consumer.Serve. Serve requires a configuration and a slice of strings,
-// each of which is the address of a Kafka broker to attempt to
-// communicate with. Serve will start a go routine for each partition
-// to consume messages and pass them to their per-topic
+// Once you've registered all your handlers you may call Consumer.Serve.
+//
+// Serve will start consuming messages and pass them to their per-topic
 // handlers. Serve itself will block until Consumer.Stop is called.
 // When Serve terminates it will return an error, which will be nil
 // under normal circumstances.

--- a/consumer/helper_test.go
+++ b/consumer/helper_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newConfig() *Config {
-	cfg := NewConfig("some-id")
-	return &cfg
-}
-
 // consumerGroupClaim implements sarama.ConsumerGroupClaim interface.
 type consumerGroupClaim struct {
 	ch    chan *sarama.ConsumerMessage


### PR DESCRIPTION
From now the main entry point of the Consumer is `New`.
`New` takes a pointer to a Config in parameter, it shouldn't be nil, otherwise, an error will be returned.

Thus `Serve` needs no parameters. The configuration is handled by `New` and the brokers's addresses are managed by `NewConfig`.

The package documentation has been updated too.

This fixes #44.