### PR TITLE
Explicit discarded behaviour

### DIFF
--- a/codec/encoder.go
+++ b/codec/encoder.go
@@ -44,7 +44,7 @@ func (e *encoder) Length() int {
 		return len(e.cache)
 	}
 
-	e.Encode()
+	_, _ = e.Encode()
 	return len(e.cache)
 }
 

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -1,6 +1,7 @@
 package consumer
 
 import (
+	"context"
 	"errors"
 
 	"github.com/Shopify/sarama"
@@ -19,8 +20,10 @@ type Config struct {
 	KafkaAddrs []string
 
 	// If non-nil, Discarded is called when a message handler
-	// returns an error.
-	Discarded func(m *sarama.ConsumerMessage, err error)
+	// returns an error. It receives the ConsumerGroupSession context as first parameter.
+	// It returns if the message should be marked as committed.
+	// If Discarded is not set, then the message will be marked as committed.
+	Discarded func(ctx context.Context, m *sarama.ConsumerMessage, err error) (mark bool)
 }
 
 // NewConfig returns a configuration filled in with default values.

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -158,7 +158,7 @@ func (c consumerGroupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, cla
 	for msg := range claim.Messages() {
 		mark := true
 		if err := h.handleMessage(ctx, msg, claim); err != nil {
-			if c.consumer.config.Discarded != nil {
+			if c.consumer.config.Discarded != nil && ctx.Err() == nil {
 				mark = c.consumer.config.Discarded(ctx, msg, err)
 			}
 		}

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -156,9 +156,10 @@ func (c consumerGroupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, cla
 	// and it's not possible to remove a topic from the handler list.
 	h := c.consumer.handlers.get(claim.Topic())
 	for msg := range claim.Messages() {
+		mark := true
 		if err := h.handleMessage(ctx, msg, claim); err != nil {
 			if c.consumer.config.Discarded != nil {
-				c.consumer.config.Discarded(msg, err)
+				mark = c.consumer.config.Discarded(ctx, msg, err)
 			}
 		}
 		if ctx.Err() != nil {
@@ -169,7 +170,9 @@ func (c consumerGroupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, cla
 			}
 			break
 		}
-		sess.MarkMessage(msg, "")
+		if mark {
+			sess.MarkMessage(msg, "")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION

With this change, the consumer configuration is explicit about what will
happen when Discarded is called.

In addition to that, it passes the ConsumerGroupSession context to know
if the consumer is being canceled by outer context at shutdown.

This is changing the configuration for Discarded signature. To be backwards
compatible, returns true in your function configuration.
